### PR TITLE
Add new variable to enable or disable setting the host header

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ environment variables is used in this image:
 * `PROXY_PORT`: Port of the service to proxy
 * `PROXY_PROTOCOL`: Protofol to the service to proxy (`http` or `https`)
 
+* `ADD_HOST_HEADER`: pass the proxy host header downstream (`true` or `false`)
+
 ```
 docker run \
   -e OID_DISCOVERY=https://my-auth-server/auth \

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -19,6 +19,7 @@ env OIDC_RENEW_ACCESS_TOKEN_ON_EXPIERY;
 env PROXY_HOST;
 env PROXY_PORT;
 env PROXY_PROTOCOL;
+env ADD_HOST_HEADER;
 
 events {
     worker_connections  1024;

--- a/nginx/conf/sites/proxy.conf
+++ b/nginx/conf/sites/proxy.conf
@@ -11,6 +11,7 @@ server {
     set_by_lua $proxy_host 'return os.getenv("PROXY_HOST")';
     set_by_lua $proxy_port 'return os.getenv("PROXY_PORT")';
     set_by_lua $proxy_protocol 'return os.getenv("PROXY_PROTOCOL")';
+    set_by_lua $add_host_header 'return os.getenv("ADD_HOST_HEADER")';
 
     error_log /dev/stdout notice;
 
@@ -25,7 +26,13 @@ server {
     location / {
       access_by_lua_file lua/auth.lua;
 
-      proxy_set_header    Host $http_host;
+      set $reverse_proxy_host $proxy_host;
+      
+      if ($add_host_header = "true") {
+        set $reverse_proxy_host $http_host;
+      }
+
+      proxy_set_header Host $reverse_proxy_host; 
       proxy_pass $proxy_protocol://$proxy_host:$proxy_port;
     }
 


### PR DESCRIPTION
If the proxy host address is running on https and using SSL certificate the HOST adresse in the request to the backend need to be the same name as the SSL certificate. 
