### PR TITLE
Disable IPv6 resolver

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -27,7 +27,7 @@ if [ -n "${NAMESERVER}" ]; then
   echo "Nameserver is: ${NAMESERVER}"
 
   echo "Patching nginx config"
-  sed -i "s/resolver.*/resolver ${NAMESERVER};/" "${NGX_CONF}"
+  sed -i "s/resolver.*/resolver ${NAMESERVER} ipv6=off;/" "${NGX_CONF}"
 fi
 
 echo "Using nginx config:"


### PR DESCRIPTION
Currently in IPv4-only environments resolver would sometimes return v6-address (for example for accounts.google.com) which breaks everything.