### PR TITLE
Changed dockerfile to add a user and, as a consequence, added an upstream connection port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,10 @@ RUN \
 COPY bootstrap.sh /usr/local/openresty/bootstrap.sh
 COPY nginx /usr/local/openresty/nginx/
 
+# Create run user
+RUN addgroup -S www && adduser -S www -G www -u 1000 -D
+RUN chown -R www:www /usr/local/openresty/
+USER www
+
+ENV UPSTREAM_PORT=8080
 ENTRYPOINT ["/usr/local/openresty/bootstrap.sh"]

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ environment variables is used in this image:
 * `PROXY_PROTOCOL`: Protocol to the service to proxy (`http` or `https`)
 
 * `ADD_HOST_HEADER`: pass the proxy host header downstream (`true` or `false`)
+* `UPSTREAM_PORT`: port on which docker-oidc-proxy listens (defaults to `8080`)
 
 ```
 docker run \

--- a/nginx/conf/nginx.conf
+++ b/nginx/conf/nginx.conf
@@ -20,6 +20,7 @@ env PROXY_HOST;
 env PROXY_PORT;
 env PROXY_PROTOCOL;
 env ADD_HOST_HEADER;
+env UPSTREAM_PORT;
 
 events {
     worker_connections  1024;

--- a/nginx/conf/sites/proxy.conf
+++ b/nginx/conf/sites/proxy.conf
@@ -1,10 +1,4 @@
 server {
-    listen 80;
-    server_name _;
-
-    large_client_header_buffers 8 64k;
-    client_header_buffer_size 64k;
-
     set_by_lua $session_secret 'return os.getenv("OID_SESSION_SECRET")';
     set_by_lua $session_check_ssi 'return os.getenv("OID_SESSION_CHECK_SSI")';
     set_by_lua $session_name 'return os.getenv("OID_SESSION_NAME")';
@@ -12,6 +6,13 @@ server {
     set_by_lua $proxy_port 'return os.getenv("PROXY_PORT")';
     set_by_lua $proxy_protocol 'return os.getenv("PROXY_PROTOCOL")';
     set_by_lua $add_host_header 'return os.getenv("ADD_HOST_HEADER")';
+    set_by_lua $upstream_port 'return os.getenv("UPSTREAM_PORT")';
+
+    listen 8080;
+    server_name _;
+
+    large_client_header_buffers 8 64k;
+    client_header_buffer_size 64k;
 
     error_log /dev/stdout notice;
 


### PR DESCRIPTION
Fixes #11  by creating a `www` user and group which will run nginx.
As this user can't run application on a protected port (like `80`), I've changed the upstream listen port to `8080`, which can be configured by an environment variable.