### PR TITLE
Update OpenResty to v1.19.9.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.13.6.2-alpine
+FROM openresty/openresty:1.19.9.1-2-alpine
 MAINTAINER Hans Kristian Flaatten <hans.flaatten@evry.com>
 
 ENV \


### PR DESCRIPTION
# Problem
The current Docker image is based on an old version of OpenResty (v1.13.6.2) with an outdated list of trusted root CA's. This is causing errors when fetching discovery URLs that are served using a Let's Encrypt TLS certificate (LE's old CA expired September 30, 2021).

# Solution
Update OpenResty to the current latest (v1.19.9.1).